### PR TITLE
fixed top menu layout issue on small screens

### DIFF
--- a/Client/Shared/MainLayout.razor
+++ b/Client/Shared/MainLayout.razor
@@ -1,6 +1,4 @@
-﻿@using BlazorApp.Client.Utils
-@using BlazorApp.Client.Utils.Constants
-@inherits LayoutComponentBase
+﻿@inherits LayoutComponentBase
 
 <div class="page @AppState.SelectedTheme">
     <div class="sidebar">
@@ -9,14 +7,7 @@
 
     <main>
         <div class="top-row px-4">
-            <select @onchange=AppState.ToggleTheme style="margin-left:1rem">
-                @foreach (var theme in themes)
-                {
-                    <option selected=@AppState.IsSelectedTheme(theme) value=@theme>@theme.ToString()</option>
-                }
-            </select>
-
-            <button @onclick="@(() => Modal?.Show<About>(string.Empty, ModalOpts))" class="badge small btn-primary">About</button>
+            <TopRow/>
         </div>
 
         <div class="container">

--- a/Client/Shared/NavMenu.razor
+++ b/Client/Shared/NavMenu.razor
@@ -1,16 +1,23 @@
 ﻿<div class="top-row ps-3 navbar navbar-dark">
-    <div class="container-fluid">
-        <a class="navbar-brand home-link" href="">Donavan Olsen</a>
-        <button title="Navigation menu" class="navbar-toggler" @onclick="ToggleNavMenu">
-            <span class="navbar-toggler-icon"></span>
-        </button>
+    
+    <div class="row">
+        <div class="col-auto">
+            <a class="navbar-brand home-link" href="">Donavan Olsen</a>
+        </div>
+        <div class="col-auto">
+            <div class="sm-screen-only">
+                <TopRow />
+            </div>
+        </div>
+        <div class="col" style="float:right">
+            <button title="Navigation menu" class="navbar-toggler" @onclick="ToggleNavMenu">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+        </div>
     </div>
 </div>
 
 <div class="@NavMenuCssClass" @onclick="ToggleNavMenu">
-        <div class="sm-screen-only nav-item">
-            <button @onclick="@(() => Modal?.Show<About>(string.Empty, ModalOpts))" class="badge small btn-primary" style="float:right">About</button>
-        </div>
     <nav class="flex-column">
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="" Match="NavLinkMatch.All">

--- a/Client/Shared/NavMenu.razor.css
+++ b/Client/Shared/NavMenu.razor.css
@@ -1,5 +1,6 @@
 .navbar-toggler {
     background-color: var(--accent);
+    float:right;
 }
 
 .top-row {
@@ -59,13 +60,16 @@
 }
 
 
-}
-
 @media (max-width:479px) {
-
 }
 
 @media (max-width: 767px) {
+    .home-link {
+        margin-right:0;
+    }
+    .sm-screen-only {
+        padding:0;
+    }
 }
 
 @media (min-width:768px) {

--- a/Client/Shared/TopRow.razor
+++ b/Client/Shared/TopRow.razor
@@ -1,0 +1,14 @@
+﻿<div class="row">
+    <div class="col">
+        <select @onchange=AppState.ToggleTheme>
+            @foreach (var theme in ThemeOptions.Themes)
+            {
+                <option selected=@AppState.IsSelectedTheme(theme) value=@theme>@theme.ToString()</option>
+            }
+        </select>
+    </div>
+    <div class="col-auto">
+        <button @onclick="@(() => Modal?.Show<About>(string.Empty, ModalOpts))" class="badge small btn-primary">About</button>
+    </div>
+</div>
+

--- a/Client/Shared/TopRow.razor.cs
+++ b/Client/Shared/TopRow.razor.cs
@@ -6,15 +6,13 @@ using Microsoft.AspNetCore.Components;
 
 namespace BlazorApp.Client.Shared
 {
-    public partial class MainLayout : LayoutComponentBase
+    public partial class TopRow : ComponentBase
     {
-        private List<string> themes =
-            new List<string> 
-            { "light-mode", "dark-mode" };
-        
-        [CascadingParameter] AppState AppState { get; set; }
-        
-        [CascadingParameter] public IModalService? Modal { get; set; }
+        [CascadingParameter]
+        public AppState AppState { get; set; }
+
+        [CascadingParameter]
+        public IModalService Modal { get; set; }
 
         private ModalOptions ModalOpts
         {
@@ -25,4 +23,5 @@ namespace BlazorApp.Client.Shared
             }
         }
     }
+
 }

--- a/Client/Shared/TopRow.razor.css
+++ b/Client/Shared/TopRow.razor.css
@@ -1,0 +1,7 @@
+﻿.theme-toggle {
+
+}
+
+.about-button {
+
+}

--- a/Client/Utils/Constants/ThemeOptions.cs
+++ b/Client/Utils/Constants/ThemeOptions.cs
@@ -1,0 +1,20 @@
+﻿namespace BlazorApp.Client.Utils.Constants
+{
+
+    public static class ThemeOptions
+    {
+        private static readonly List<string> themes 
+            = new List<string>()
+            { "light-mode", "dark-mode" };
+
+        public static List<string> Themes 
+        { 
+            get 
+            {
+                return themes;
+            }
+        }
+            
+
+    }
+}

--- a/Client/_Imports.razor
+++ b/Client/_Imports.razor
@@ -12,4 +12,6 @@
 @using Microsoft.JSInterop
 @using System.Net.Http
 @using System.Net.Http.Json
+@using BlazorApp.Client.Utils
+@using BlazorApp.Client.Utils.Constants
 

--- a/MySite.sln
+++ b/MySite.sln
@@ -9,7 +9,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Api", "Api\Api.csproj", "{4
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shared", "Shared\Shared.csproj", "{CF7C3565-A482-412A-BE7F-B2D5AC0DFB88}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PersonalSiteTests", "PersonalSiteTests\PersonalSiteTests.csproj", "{C87330E0-280C-4E2C-9CA7-B2B0463ADD3A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PersonalSiteTests", "PersonalSiteTests\PersonalSiteTests.csproj", "{C87330E0-280C-4E2C-9CA7-B2B0463ADD3A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
created TopMenu component to reuse between NavMenu and MainLayout
dark-mode toggle is now visible when navbar is collapsed
Top menu flows smothly through various brake points

fixes #45
